### PR TITLE
[ADD] add vue and wail for adjust. don't use version 0.2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ For browser you could get the dist file [here](./dist/driver-lib.min.js).
 - [hogan.js](https://www.npmjs.com/package/hogan.js)
 - [url-search-params](https://www.npmjs.com/package/url-search-params)
 - [numeral](https://www.npmjs.com/package/numeral)
+- [vue](https://www.npmjs.com/package/vue)
 
 [ci-img]:https://img.shields.io/travis/RiceQuant-FE/driver-lib.svg?style=flat-square
 [ci-url]:https://travis-ci.org/RiceQuant-FE/driver-lib

--- a/config/build.js
+++ b/config/build.js
@@ -2,9 +2,11 @@ import 'jquery/dist/jquery.min.js';
 /* LODASH */
 import 'babel-polyfill/dist/polyfill.min.js';
 import 'whatwg-fetch';
-import 'riot/riot.min.js';
 import 'moment/min/moment.min.js';
 import 'numeral/min/numeral.min.js';
+
+import V from 'vue/dist/vue.esm.js';
+window.Vue = V;
 
 import H from 'hogan.js/dist/template-3.0.2.min.js';
 window.Hogan = H;

--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ lodashBuilder({ // Make custom lodash
 		)
 	);
 }).then(() => rollup({ // Rollup pack
-	entry: BUILD_PATH,
+	input: BUILD_PATH,
 	context: 'window',
 	plugins: [
 		require('rollup-plugin-node-resolve')({
@@ -48,8 +48,8 @@ lodashBuilder({ // Make custom lodash
 		})
 	]
 })).then(bundle => bundle.write({ // Write bundle output
-	dest: 'dist/driver-lib.js',
-	moduleName: '',
+	file: 'dist/driver-lib.js',
+	name: '',
 	format: 'iife'
 })).catch(err => {
 	console.error(err);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "driver-lib",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "driver lib",
   "main": "dist/driver-lib.min.js",
   "scripts": {
@@ -38,6 +38,7 @@
     "rollup-plugin-node-resolve": "3.0.0",
     "uglify-es": "3.0.28",
     "url-search-params": "0.10.0",
+    "vue": "2.4.3",
     "whatwg-fetch": "2.0.3"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3391,6 +3391,10 @@ vlq@^0.2.1:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/vlq/-/vlq-0.2.2.tgz#e316d5257b40b86bb43cb8d5fea5d7f54d6b0ca1"
 
+vue@^2.4.3:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/vue/-/vue-2.4.3.tgz#55fee0ec509cf2e10aa73b34b15219e92a9ab9ea"
+
 webidl-conversions@^4.0.0, webidl-conversions@^4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"


### PR DESCRIPTION
I can't compile it here, but I've changed some of the code.

And I compile the message here:

```shell
> driver-lib@0.2.3 build /Users/quietboy/git/driver-lib
> npm run rollup && npm run uglify


> driver-lib@0.2.3 rollup /Users/quietboy/git/driver-lib
> node index.js

The final argument to magicString.overwrite(...) should be an options object. See https://github.com/rich-harris/magic-string

> driver-lib@0.2.3 uglify /Users/quietboy/git/driver-lib
> uglifyjs -c -m -o dist/driver-lib.min.js dist/driver-lib.js
```